### PR TITLE
Escape special characters in chart `StrVal`

### DIFF
--- a/lib/axlsx/drawing/str_val.rb
+++ b/lib/axlsx/drawing/str_val.rb
@@ -27,7 +27,7 @@ module Axlsx
     def to_xml_string(idx, str = "")
       Axlsx::validate_unsigned_int(idx)
       if !v.to_s.empty?
-        str << ('<c:pt idx="' << idx.to_s << '"><c:v>' << v.to_s << '</c:v></c:pt>')
+        str << ('<c:pt idx="' << idx.to_s << '"><c:v>' << ::CGI.escapeHTML(v.to_s) << '</c:v></c:pt>')
       end
     end
   end

--- a/test/drawing/tc_str_val.rb
+++ b/test/drawing/tc_str_val.rb
@@ -4,6 +4,7 @@ class TestStrVal < Test::Unit::TestCase
 
   def setup
     @str_val = Axlsx::StrVal.new :v => "1"
+    @str_val_with_special_characters = Axlsx::StrVal.new :v => "a & b <c>"
   end
 
   def test_initialize
@@ -16,6 +17,14 @@ class TestStrVal < Test::Unit::TestCase
     str << @str_val.to_xml_string(0)
     doc = Nokogiri::XML(str)
     assert_equal(doc.xpath("//c:pt/c:v[text()='1']").size, 1)
+  end
+
+  def test_to_xml_string_special_characters
+    str = '<?xml version="1.0" encoding="UTF-8"?>'
+    str << '<c:chartSpace xmlns:c="' << Axlsx::XML_NS_C << '">'
+    str << @str_val_with_special_characters.to_xml_string(0)
+    doc = Nokogiri::XML(str)
+    assert_equal(doc.xpath("//c:pt/c:v[text()='a & b <c>']").size, 1)
   end
 
 end


### PR DESCRIPTION
So that, for example, pie charts can render with labels
that include an ampersand
